### PR TITLE
Fix/over polling

### DIFF
--- a/src/components/dashboard/PatientTimeline.jsx
+++ b/src/components/dashboard/PatientTimeline.jsx
@@ -143,7 +143,7 @@ const BasicTimeline = (props) => {
           />
         ))}
 
-        {/* Summary and End items */}
+        {/* Screening review and End items */}
         <TimelineItem>
           <TimelineSeparator>
             <TimelineDot
@@ -156,7 +156,7 @@ const BasicTimeline = (props) => {
               href='/app/summary'
               onClick={(event) => navigateTo(event, navigate, 'summary', scrollTop)}
             >
-              Summary [View Only]
+              Screening Review [View Only]
             </a>
           </TimelineContent>
         </TimelineItem>

--- a/src/forms/FitForm.jsx
+++ b/src/forms/FitForm.jsx
@@ -1,0 +1,10 @@
+import PlaceholderStationForm from './PlaceholderStationForm'
+
+const FitForm = () => (
+  <PlaceholderStationForm
+    formName='fitForm'
+    title='Fecal Immunochemical Test'
+  />
+)
+
+export default FitForm

--- a/src/forms/PlaceholderStationForm.jsx
+++ b/src/forms/PlaceholderStationForm.jsx
@@ -1,0 +1,103 @@
+import { Button, CircularProgress, Divider, Paper, Typography } from '@mui/material'
+import { FastField, Form, Formik } from 'formik'
+import { useContext, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import * as Yup from 'yup'
+
+import { submitForm } from '../api/api.jsx'
+import { FormContext } from '../api/utils.js'
+import CustomRadioGroup from '../components/form-components/CustomRadioGroup.jsx'
+import ErrorNotification from '../components/form-components/ErrorNotification.jsx'
+import { getSavedData } from '../services/patientData'
+import './fieldPadding.css'
+import './forms.css'
+
+const initialValues = {
+  placeholderCompleted: '',
+}
+
+const validationSchema = Yup.object({
+  placeholderCompleted: Yup.string().required('Required'),
+})
+
+const completionOptions = [
+  { label: 'Yes', value: 'Yes' },
+  { label: 'No', value: 'No' },
+]
+
+const PlaceholderStationForm = ({ formName, title }) => {
+  const { patientId } = useContext(FormContext)
+  const [savedData, setSavedData] = useState(initialValues)
+  const [loading, setLoading] = useState(false)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const savedData = await getSavedData(patientId, formName)
+      setSavedData({ ...initialValues, ...savedData })
+    }
+    fetchData()
+  }, [patientId, formName])
+
+  const handleSubmit = async (values, { setSubmitting }) => {
+    setLoading(true)
+    const response = await submitForm(values, patientId, formName)
+    setLoading(false)
+    setSubmitting(false)
+
+    if (response.result) {
+      alert('Successfully submitted form')
+      navigate('/app/dashboard', { replace: true })
+    } else {
+      alert(`Unsuccessful. ${response.error}`)
+    }
+  }
+
+  return (
+    <Paper elevation={2}>
+      <Formik
+        initialValues={savedData}
+        validationSchema={validationSchema}
+        enableReinitialize
+        onSubmit={handleSubmit}
+      >
+        {({ isSubmitting, errors, submitCount }) => (
+          <Form className='fieldPadding'>
+            <Typography variant='h4'>
+              <strong>{title}</strong>
+            </Typography>
+            <Typography fontWeight='bold'>
+              Has the patient completed the {title} station?
+            </Typography>
+            <FastField
+              name='placeholderCompleted'
+              label='placeholderCompleted'
+              component={CustomRadioGroup}
+              options={completionOptions}
+              row
+            />
+
+            <ErrorNotification
+              show={submitCount > 0 && Object.keys(errors || {}).length > 0}
+              message='Please fill in all required fields correctly.'
+            />
+
+            <div style={{ marginTop: 16, display: 'flex', justifyContent: 'center' }}>
+              {loading || isSubmitting ? (
+                <CircularProgress />
+              ) : (
+                <Button type='submit' variant='contained' color='primary'>
+                  Submit
+                </Button>
+              )}
+            </div>
+            <br />
+            <Divider />
+          </Form>
+        )}
+      </Formik>
+    </Paper>
+  )
+}
+
+export default PlaceholderStationForm

--- a/src/forms/ScoliosisForm.jsx
+++ b/src/forms/ScoliosisForm.jsx
@@ -1,0 +1,10 @@
+import PlaceholderStationForm from './PlaceholderStationForm'
+
+const ScoliosisForm = () => (
+  <PlaceholderStationForm
+    formName='scoliosisForm'
+    title='Scoliosis'
+  />
+)
+
+export default ScoliosisForm

--- a/src/forms/formKeys.js
+++ b/src/forms/formKeys.js
@@ -20,6 +20,7 @@ export const FORM_COLLECTION_TO_KEY = {
   ophthalForm: 'ophthal',
   osteoForm: 'osteo',
   fitForm: 'fit',
+  scoliosisForm: 'scoliosis',
   geriEbasDepForm: 'geriEbasDep',
   geriFrailScaleForm: 'geriFrailScale',
   geriParQForm: 'geriParQ',

--- a/src/forms/forms.json
+++ b/src/forms/forms.json
@@ -4,6 +4,7 @@
   "summaryForm": "summaryForm",
   "osteoForm": "osteoForm",
   "fitForm": "fitForm",
+  "scoliosisForm": "scoliosisForm",
   "geriAmtForm": "geriAmtForm",
   "geriEbasDepForm": "geriEbasDepForm",
   "geriFrailScaleForm": "geriFrailScaleForm",

--- a/src/pages/DoctorAdmin.jsx
+++ b/src/pages/DoctorAdmin.jsx
@@ -13,10 +13,25 @@ const DoctorAdmin = () => {
   const [pdfQueue, setPdfQueue] = useState([])
   const [printedQueue, setPrintedQueue] = useState([])
   const [loading, setLoading] = useState(true)
-  const [refresh, setRefresh] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const [admin, setAdmin] = useState(false)
   const [checkingAdmin, setCheckingAdmin] = useState(true) // NEW
   const [view, setView] = useState('queue') // 'queue' = active jobs, 'history' = printed jobs
+  const [hasLoadedHistory, setHasLoadedHistory] = useState(false)
+
+  const sortNewestFirst = (items) =>
+    [...items].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+
+  const fetchCurrentQueue = async () => {
+    const unprinted = await getUnprintedDocPdfQueue()
+    setPdfQueue(sortNewestFirst(unprinted))
+  }
+
+  const fetchPrintHistory = async () => {
+    const printed = await getPrintedDocPdfQueue()
+    setPrintedQueue(sortNewestFirst(printed))
+    setHasLoadedHistory(true)
+  }
 
   // runs only on page load
   useEffect(() => {
@@ -32,22 +47,15 @@ const DoctorAdmin = () => {
 
         if (!isAdminUser) return
 
-        // Use the new separate functions
         const unprinted = await getUnprintedDocPdfQueue()
-        const printed = await getPrintedDocPdfQueue()
 
         if (!isMounted) return
-
-        // Sort by newest first
-        unprinted.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-        printed.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-
-        setPdfQueue(unprinted)
-        setPrintedQueue(printed)
+        setPdfQueue(sortNewestFirst(unprinted))
         setLoading(false)
       } catch (err) {
         console.error('Initial fetch error:', err)
         setCheckingAdmin(false)
+        setLoading(false)
       }
     }
 
@@ -57,50 +65,45 @@ const DoctorAdmin = () => {
     }
   }, [])
 
-  // polling to refresh queue every 5sec while tab is visible
-  useEffect(() => {
-    let isMounted = true
-
-    const fetchQueue = async () => {
-      try {
-        const unprinted = await getUnprintedDocPdfQueue()
-        const printed = await getPrintedDocPdfQueue()
-
-        if (!isMounted) return
-
-        unprinted.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-        printed.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-
-        setPdfQueue(unprinted)
-        setPrintedQueue(printed)
-      } catch (err) {
-        console.error('Failed to fetch PDF queue:', err)
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    try {
+      if (view === 'history') {
+        await fetchPrintHistory()
+      } else {
+        await fetchCurrentQueue()
       }
+    } catch (err) {
+      console.error('Failed to refresh PDF queue:', err)
+    } finally {
+      setRefreshing(false)
     }
+  }
 
-    fetchQueue()
+  const handleShowHistory = async () => {
+    setView('history')
+    if (hasLoadedHistory) return
 
-    const interval = setInterval(() => {
-      if (document.visibilityState === 'visible') {
-        setRefresh((r) => !r)
-      }
-    }, 5000)
-
-    return () => {
-      isMounted = false
-      clearInterval(interval)
+    setRefreshing(true)
+    try {
+      await fetchPrintHistory()
+    } catch (err) {
+      console.error('Failed to fetch print history:', err)
+    } finally {
+      setRefreshing(false)
     }
-  }, [refresh])
+  }
 
   const handlePrint = async (entry) => {
     await generateDoctorPdf(entry)
     await markDocPdfAsPrinted(entry._id)
-    setRefresh((r) => !r)
+    setHasLoadedHistory(false)
+    await fetchCurrentQueue()
   }
 
   const handleRemove = async (entry) => {
     await deleteDocPdfFromQueue(entry._id)
-    setRefresh((r) => !r)
+    await fetchCurrentQueue()
   }
 
   if (checkingAdmin) return <CircularProgress />
@@ -122,13 +125,16 @@ const DoctorAdmin = () => {
         </Button>
         <Button
           variant={view === 'history' ? 'contained' : 'outlined'}
-          onClick={() => setView('history')}
+          onClick={handleShowHistory}
         >
           Show Print History
         </Button>
+        <Button variant='outlined' onClick={handleRefresh} disabled={refreshing}>
+          {refreshing ? 'Refreshing...' : 'Refresh'}
+        </Button>
       </Stack>
 
-      {loading ? (
+      {loading || refreshing ? (
         <CircularProgress />
       ) : view === 'history' ? (
         printedQueue.length === 0 ? (

--- a/src/pages/FormAAdmin.jsx
+++ b/src/pages/FormAAdmin.jsx
@@ -13,10 +13,25 @@ const FormAAdmin = () => {
   const [pdfQueue, setPdfQueue] = useState([])
   const [printedQueue, setPrintedQueue] = useState([])
   const [loading, setLoading] = useState(true)
-  const [refresh, setRefresh] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const [admin, setAdmin] = useState(false)
   const [checkingAdmin, setCheckingAdmin] = useState(true) // NEW
   const [view, setView] = useState('queue') // 'queue' = active jobs, 'history' = printed jobs
+  const [hasLoadedHistory, setHasLoadedHistory] = useState(false)
+
+  const sortNewestFirst = (items) =>
+    [...items].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+
+  const fetchCurrentQueue = async () => {
+    const unprinted = await getUnprintedFormAPdfQueue()
+    setPdfQueue(sortNewestFirst(unprinted))
+  }
+
+  const fetchPrintHistory = async () => {
+    const printed = await getPrintedFormAPdfQueue()
+    setPrintedQueue(sortNewestFirst(printed))
+    setHasLoadedHistory(true)
+  }
 
   // runs only on page load
   useEffect(() => {
@@ -34,20 +49,14 @@ const FormAAdmin = () => {
         if (!isAdminUser) return
 
         const unprinted = await getUnprintedFormAPdfQueue()
-        const printed = await getPrintedFormAPdfQueue()
 
         if (!isMounted) return
-
-        // sort by newest first
-        unprinted.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-        printed.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-
-        setPdfQueue(unprinted)
-        setPrintedQueue(printed)
+        setPdfQueue(sortNewestFirst(unprinted))
         setLoading(false)
       } catch (err) {
         console.error('Initial fetch error:', err)
         setCheckingAdmin(false)
+        setLoading(false)
       }
     }
 
@@ -57,46 +66,41 @@ const FormAAdmin = () => {
     }
   }, [])
 
-  // polling to refresh queue every 5sec while tab is visible
-  useEffect(() => {
-    let isMounted = true
-
-    const fetchQueue = async () => {
-      try {
-        const unprinted = await getUnprintedFormAPdfQueue()
-        const printed = await getPrintedFormAPdfQueue()
-
-        if (!isMounted) return
-
-        unprinted.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-        printed.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-
-        setPdfQueue(unprinted)
-        setPrintedQueue(printed)
-      } catch (err) {
-        console.error('Failed to fetch PDF queue:', err)
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    try {
+      if (view === 'history') {
+        await fetchPrintHistory()
+      } else {
+        await fetchCurrentQueue()
       }
+    } catch (err) {
+      console.error('Failed to refresh PDF queue:', err)
+    } finally {
+      setRefreshing(false)
     }
+  }
 
-    fetchQueue()
+  const handleShowHistory = async () => {
+    setView('history')
+    if (hasLoadedHistory) return
 
-    const interval = setInterval(() => {
-      if (document.visibilityState === 'visible') {
-        setRefresh((r) => !r)
-      }
-    }, 5000)
-
-    return () => {
-      isMounted = false
-      clearInterval(interval)
+    setRefreshing(true)
+    try {
+      await fetchPrintHistory()
+    } catch (err) {
+      console.error('Failed to fetch print history:', err)
+    } finally {
+      setRefreshing(false)
     }
-  }, [refresh])
+  }
 
   const handlePrint = async (entry) => {
     try {
       await generateFormAPdf(entry.patientId)
       await markFormAAsPrinted(entry._id)
-      setRefresh((r) => !r)
+      setHasLoadedHistory(false)
+      await fetchCurrentQueue()
     } catch (error) {
       console.error('Failed to generate Form A PDF:', error)
       alert('Unable to generate Form A PDF because backend station eligibility is unavailable.')
@@ -115,7 +119,7 @@ const FormAAdmin = () => {
   // Update the handleRemove function:
   const handleRemove = async (entry) => {
     await deleteFormAFromQueue(entry._id)
-    setRefresh((r) => !r)
+    await fetchCurrentQueue()
   }
 
   if (checkingAdmin) return <CircularProgress />
@@ -137,13 +141,16 @@ const FormAAdmin = () => {
         </Button>
         <Button
           variant={view === 'history' ? 'contained' : 'outlined'}
-          onClick={() => setView('history')}
+          onClick={handleShowHistory}
         >
           Show Print History
         </Button>
+        <Button variant='outlined' onClick={handleRefresh} disabled={refreshing}>
+          {refreshing ? 'Refreshing...' : 'Refresh'}
+        </Button>
       </Stack>
 
-      {loading ? (
+      {loading || refreshing ? (
         <CircularProgress />
       ) : view === 'history' ? (
         printedQueue.length === 0 ? (

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -36,6 +36,8 @@ import GeriMobilityTabs from './forms/GeriMobilityTabs/GeriMobility'
 import GeriCognitiveTabs from './forms/GeriCognitiveTabs/GeriCognitive'
 import MammobusForm from './forms/MammobusForm'
 import PodiatryForm from './forms/PodiatryForm'
+import FitForm from './forms/FitForm'
+import ScoliosisForm from './forms/ScoliosisForm'
 
 import Eligibility from './pages/Eligibility'
 
@@ -55,8 +57,10 @@ const routes = [
       { path: 'reg', element: <RegForm /> },
       { path: 'vax', element: <VaccineForm /> },
       { path: 'hsg', element: <HsgForm /> },
+      { path: 'fit', element: <FitForm /> },
       { path: 'audio', element: <AudiometryForm /> },
       { path: 'ophthal', element: <OphthalForm /> },
+      { path: 'scoliosis', element: <ScoliosisForm /> },
       { path: 'gericog', element: <GeriCognitiveTabs /> },
       { path: 'triage', element: <TriageForm /> },
       { path: 'osteoporosis', element: <OsteoForm /> },


### PR DESCRIPTION
Fixes #235

Originally polls database every 5 seconds for every tab open for latest print history. Implemented manual refresh instead of auto polling.  Will discuss on whether live updates are necessary and scale of users before deciding whether to integrate SSE to complement manual refresh.