### PR TITLE
[Bug] Fix bug where user is able to reach /login when logged in

### DIFF
--- a/src/components/AdminRoute.jsx
+++ b/src/components/AdminRoute.jsx
@@ -1,0 +1,50 @@
+import React, { useContext, useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import { Navigate } from 'react-router-dom'
+import { LoginContext } from '../App.jsx'
+import { getProfile } from '../services/authSession'
+
+const AdminRoute = ({ children, redirectTo = '/app/registration' }) => {
+  const { setProfile } = useContext(LoginContext)
+  const [allowed, setAllowed] = useState(null)
+
+  useEffect(() => {
+    let active = true
+
+    const checkAdmin = async () => {
+      const profile = await getProfile()
+
+      if (!active) return
+
+      if (profile) {
+        setProfile(profile)
+        localStorage.setItem('profile', JSON.stringify(profile))
+      }
+
+      setAllowed(Boolean(profile?.is_admin))
+    }
+
+    checkAdmin()
+
+    return () => {
+      active = false
+    }
+  }, [setProfile])
+
+  if (allowed === null) {
+    return null
+  }
+
+  if (!allowed) {
+    return <Navigate to={redirectTo} replace />
+  }
+
+  return children
+}
+
+AdminRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+  redirectTo: PropTypes.string,
+}
+
+export default AdminRoute

--- a/src/components/DefaultRoute.jsx
+++ b/src/components/DefaultRoute.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { isLoggedin } from '../services/authSession'
+
+const DefaultRoute = () => (
+  <Navigate to={isLoggedin() ? '/app/registration' : '/login'} replace />
+)
+
+export default DefaultRoute

--- a/src/components/GuestOnlyRoute.jsx
+++ b/src/components/GuestOnlyRoute.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Navigate } from 'react-router-dom'
+import { isLoggedin } from '../services/authSession'
+
+const GuestOnlyRoute = ({ children }) => {
+  if (isLoggedin()) {
+    return <Navigate to='/app/registration' replace />
+  }
+
+  return children
+}
+
+GuestOnlyRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default GuestOnlyRoute

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Navigate } from 'react-router-dom'
+import { isLoggedin } from '../services/authSession'
+
+const ProtectedRoute = ({ children }) => {
+  if (!isLoggedin()) {
+    return <Navigate to='/login' replace />
+  }
+
+  return children
+}
+
+ProtectedRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default ProtectedRoute

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,6 +1,9 @@
 import { Navigate } from 'react-router-dom'
 import DashboardLayout from 'src/components/DashboardLayout'
+import DefaultRoute from 'src/components/DefaultRoute'
+import GuestOnlyRoute from 'src/components/GuestOnlyRoute'
 import MainLayout from 'src/components/MainLayout'
+import ProtectedRoute from 'src/components/ProtectedRoute'
 import Queue from './pages/Queue'
 import Dashboard from 'src/pages/Dashboard'
 import Login from 'src/pages/Login'
@@ -42,7 +45,11 @@ import Eligibility from './pages/Eligibility'
 const routes = [
   {
     path: 'app',
-    element: <DashboardLayout />,
+    element: (
+      <ProtectedRoute>
+        <DashboardLayout />
+      </ProtectedRoute>
+    ),
     children: [
       { path: 'registration', element: <Registration /> },
       { path: 'dashboard', element: <Dashboard /> },
@@ -82,11 +89,18 @@ const routes = [
     path: '/',
     element: <MainLayout />,
     children: [
-      { path: 'login', element: <Login /> },
+      {
+        path: 'login',
+        element: (
+          <GuestOnlyRoute>
+            <Login />
+          </GuestOnlyRoute>
+        ),
+      },
       { path: 'reset', element: <Reset /> },
       { path: 'register', element: <Register /> },
       { path: '404', element: <NotFound /> },
-      { path: '/', element: <Navigate to='/login' /> },
+      { path: '/', element: <DefaultRoute /> },
       { path: '*', element: <Navigate to='/404' /> },
     ],
   },

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -85,7 +85,6 @@ const routes = [
           </AdminRoute>
         ),
       },
-      { path: 'edit', element: <Edit /> },
       { path: 'wce', element: <WceTabs /> },
       { path: 'queue', element: <Queue /> },
       { path: 'eligibility', element: <Eligibility /> },

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,4 +1,5 @@
 import { Navigate } from 'react-router-dom'
+import AdminRoute from 'src/components/AdminRoute'
 import DashboardLayout from 'src/components/DashboardLayout'
 import DefaultRoute from 'src/components/DefaultRoute'
 import GuestOnlyRoute from 'src/components/GuestOnlyRoute'
@@ -72,7 +73,14 @@ const routes = [
       { path: 'mentalhealth', element: <MentalHealthForm /> },
       { path: 'oralhealth', element: <OralHealthForm /> },
       { path: 'hpv', element: <HpvForm /> },
-      { path: 'manage', element: <ManageVolunteers /> },
+      {
+        path: 'manage',
+        element: (
+          <AdminRoute>
+            <ManageVolunteers />
+          </AdminRoute>
+        ),
+      },
       { path: 'edit', element: <Edit /> },
       { path: 'wce', element: <WceTabs /> },
       { path: 'queue', element: <Queue /> },


### PR DESCRIPTION
Fixed #261 
Larger changes than necessary to minimise latency as a result of this bug fix. Adhered strictly to open-close principle, hence introduction of `DefaultRoute`, `GuestOnlyRoute` and `ProtectedRoute`.

However, routes that are not /app/* (namely /reset, /register, /404 and wildcards) are not protected routes, and could be subject to the problem of not logged in but able to briefly see the page before it redirects.