### PR TITLE
[Bug] Bugfix for selectedPatient

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,13 +2,18 @@ import 'react-perfect-scrollbar/dist/css/styles.css'
 import { useRoutes } from 'react-router-dom'
 import { ThemeProvider } from '@mui/material/styles'
 import routes from 'src/routes'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import customTheme from './theme'
 // import { isLoggedin } from './services/authSession'
 import { FormContext } from './api/utils'
 import FormSubmitStatusHost from './components/form-components/FormSubmitStatusHost'
 import './App.css'
-import { clearPersistedPatient, loadPersistedPatient, savePersistedPatient } from './utils/patientPersistence'
+import {
+  clearPersistedPatient,
+  loadPersistedPatient,
+  PATIENT_CLEARED_EVENT,
+  savePersistedPatient,
+} from './utils/patientPersistence'
 
 export const LoginContext = React.createContext({
   login: false,
@@ -19,8 +24,9 @@ export const LoginContext = React.createContext({
 
 const App = () => {
   // const { setProfile } = useContext(LoginContext)
-  const [patientId, setPatientId] = useState(() => loadPersistedPatient().patientId)
-  const [patientInfo, setPatientInfo] = useState(() => loadPersistedPatient().patientInfo)
+  const [persistedPatient] = useState(loadPersistedPatient)
+  const [patientId, setPatientId] = useState(() => persistedPatient.patientId)
+  const [patientInfo, setPatientInfo] = useState(() => persistedPatient.patientInfo)
   // const [login, isLogin] = useState(isLoggedin())
   // const profile = undefined
   const [login, isLogin] = useState(!!localStorage.getItem('authToken')) // start as false, not isLoggedin()
@@ -31,6 +37,19 @@ const App = () => {
       return null
     }
   })
+
+  useEffect(() => {
+    const handlePatientCleared = () => {
+      setPatientId(-1)
+      setPatientInfo({})
+    }
+
+    window.addEventListener(PATIENT_CLEARED_EVENT, handlePatientCleared)
+
+    return () => {
+      window.removeEventListener(PATIENT_CLEARED_EVENT, handlePatientCleared)
+    }
+  }, [])
 
   const updatePatientId = (new_id) => {
     setPatientId(new_id)

--- a/src/forms/RegForm.jsx
+++ b/src/forms/RegForm.jsx
@@ -54,7 +54,7 @@ const initialValues = {
 const formName = 'registrationForm'
 
 const RegForm = () => {
-  const { patientId, updatePatientId, updatePatientInfo } = useContext(FormContext)
+  const { patientId, updatePatientInfo } = useContext(FormContext)
   const [loading, isLoading] = useState(true)
   const navigate = useNavigate()
   const [savedData, setSavedData] = useState(initialValues)
@@ -156,8 +156,7 @@ const RegForm = () => {
         console.log('response data: ' + response.qNum)
         await showFormSubmitSuccess()
         console.log('Successfully submitted form')
-        updatePatientInfo(response.data)
-        updatePatientId(response.qNum)
+        updatePatientInfo({ ...response.data, queueNo: response.qNum })
         navigate('/app/dashboard')
       }, 80)
     } else {

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import PatientTimeline from 'src/components/dashboard/PatientTimeline'
 import { Helmet } from 'react-helmet-async'
 import { FormContext } from 'src/api/utils'
 import { useNavigate } from 'react-router-dom'
+import { isLoggedin } from '../services/authSession'
 
 const Dashboard = () => {
   const { patientId } = useContext(FormContext)
@@ -13,6 +14,11 @@ const Dashboard = () => {
   useEffect(() => {
     console.log("Current Patient ID: " + patientId)
     if (patientId === -1) {
+      if (!isLoggedin()) {
+        navigate('/login', { replace: true })
+        return
+      }
+
       alert('You need to enter the queue number for the patient you are attending to!')
       navigate('/app/registration', { replace: true })
     } else {

--- a/src/services/authSession.js
+++ b/src/services/authSession.js
@@ -1,8 +1,10 @@
 import { getCurrentProfile } from '../api/profilesApi'
+import { clearPersistedPatient } from '../utils/patientPersistence'
 
 const clearAuthSession = () => {
   localStorage.removeItem('authToken')
   localStorage.removeItem('profile')
+  clearPersistedPatient()
 }
 
 const decodeJwtPayload = (token) => {

--- a/src/utils/patientPersistence.js
+++ b/src/utils/patientPersistence.js
@@ -1,4 +1,5 @@
 const STORAGE_KEY = 'selectedPatient'
+export const PATIENT_CLEARED_EVENT = 'patient-selection-cleared'
 
 export function loadPersistedPatient() {
   try {
@@ -26,4 +27,5 @@ export function savePersistedPatient(patientId, patientInfo = {}) {
 
 export function clearPersistedPatient() {
   localStorage.removeItem(STORAGE_KEY)
+  window.dispatchEvent(new Event(PATIENT_CLEARED_EVENT))
 }

--- a/test/unit/Dashboard.test.jsx
+++ b/test/unit/Dashboard.test.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import Dashboard from '../../src/pages/Dashboard'
+import { FormContext } from '../../src/api/utils'
+import { isLoggedin } from '../../src/services/authSession'
+
+vi.mock('../../src/services/authSession', () => ({
+  isLoggedin: vi.fn(),
+}))
+
+vi.mock('../../src/components/dashboard/PatientTimeline', () => ({
+  default: ({ patientId }) => <div>Timeline for {patientId}</div>,
+}))
+
+function CurrentPath() {
+  const location = useLocation()
+  return <div data-testid='current-path'>{location.pathname}</div>
+}
+
+function renderDashboard(patientId) {
+  return render(
+    <FormContext.Provider value={{ patientId }}>
+      <MemoryRouter initialEntries={['/app/dashboard']}>
+        <Routes>
+          <Route path='/app/dashboard' element={<Dashboard />} />
+          <Route path='/login' element={<CurrentPath />} />
+          <Route path='/app/registration' element={<CurrentPath />} />
+        </Routes>
+      </MemoryRouter>
+    </FormContext.Provider>
+  )
+}
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(window, 'alert').mockImplementation(() => {})
+  })
+
+  it('redirects logged-out users without showing the select-patient alert', async () => {
+    isLoggedin.mockReturnValue(false)
+
+    renderDashboard(-1)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-path')).toHaveTextContent('/login')
+    })
+    expect(window.alert).not.toHaveBeenCalled()
+  })
+
+  it('alerts logged-in users who open the dashboard without a selected patient', async () => {
+    isLoggedin.mockReturnValue(true)
+
+    renderDashboard(-1)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-path')).toHaveTextContent('/app/registration')
+    })
+    expect(window.alert).toHaveBeenCalledWith(
+      'You need to enter the queue number for the patient you are attending to!'
+    )
+  })
+
+  it('renders the patient timeline when a patient is selected', () => {
+    renderDashboard(123)
+
+    expect(screen.getByText('Timeline for 123')).toBeInTheDocument()
+    expect(window.alert).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/Dashboard.test.jsx
+++ b/test/unit/Dashboard.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { HelmetProvider } from 'react-helmet-async'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import Dashboard from '../../src/pages/Dashboard'
 import { FormContext } from '../../src/api/utils'
@@ -21,15 +22,17 @@ function CurrentPath() {
 
 function renderDashboard(patientId) {
   return render(
-    <FormContext.Provider value={{ patientId }}>
-      <MemoryRouter initialEntries={['/app/dashboard']}>
-        <Routes>
-          <Route path='/app/dashboard' element={<Dashboard />} />
-          <Route path='/login' element={<CurrentPath />} />
-          <Route path='/app/registration' element={<CurrentPath />} />
-        </Routes>
-      </MemoryRouter>
-    </FormContext.Provider>
+    <HelmetProvider>
+      <FormContext.Provider value={{ patientId }}>
+        <MemoryRouter initialEntries={['/app/dashboard']}>
+          <Routes>
+            <Route path='/app/dashboard' element={<Dashboard />} />
+            <Route path='/login' element={<CurrentPath />} />
+            <Route path='/app/registration' element={<CurrentPath />} />
+          </Routes>
+        </MemoryRouter>
+      </FormContext.Provider>
+    </HelmetProvider>
   )
 }
 

--- a/test/unit/authSession.test.js
+++ b/test/unit/authSession.test.js
@@ -12,6 +12,13 @@ vi.mock('../../src/api/profilesApi', () => ({
   getCurrentProfile: vi.fn(),
 }))
 
+const createJwt = (payload) => {
+  const encode = (value) =>
+    btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+
+  return `${encode({ alg: 'none', typ: 'JWT' })}.${encode(payload)}.signature`
+}
+
 describe('authSession', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -36,11 +43,24 @@ describe('authSession', () => {
   it('logs out by removing auth session values', async () => {
     localStorage.setItem('authToken', 'token-123')
     localStorage.setItem('profile', '{"name":"Ada"}')
+    localStorage.setItem('selectedPatient', '{"patientId":123,"patientInfo":{"queueNo":123}}')
 
     await logOut()
 
     expect(localStorage.getItem('authToken')).toBeNull()
     expect(localStorage.getItem('profile')).toBeNull()
+    expect(localStorage.getItem('selectedPatient')).toBeNull()
+  })
+
+  it('clears selected patient when an expired token is detected', () => {
+    localStorage.setItem('authToken', createJwt({ exp: Math.floor(Date.now() / 1000) - 60 }))
+    localStorage.setItem('profile', '{"name":"Ada"}')
+    localStorage.setItem('selectedPatient', '{"patientId":123,"patientInfo":{"queueNo":123}}')
+
+    expect(isLoggedin()).toBe(false)
+    expect(localStorage.getItem('authToken')).toBeNull()
+    expect(localStorage.getItem('profile')).toBeNull()
+    expect(localStorage.getItem('selectedPatient')).toBeNull()
   })
 
   it('returns null for getProfile when logged out', async () => {

--- a/test/unit/patientPersistence.test.js
+++ b/test/unit/patientPersistence.test.js
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearPersistedPatient,
+  loadPersistedPatient,
+  PATIENT_CLEARED_EVENT,
+  savePersistedPatient,
+} from '../../src/utils/patientPersistence'
+
+describe('patientPersistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('loads an empty patient when nothing is persisted', () => {
+    expect(loadPersistedPatient()).toEqual({ patientId: -1, patientInfo: {} })
+  })
+
+  it('saves and loads the selected patient', () => {
+    const patientInfo = { queueNo: 123, initials: 'Ada', age: 45 }
+
+    savePersistedPatient(123, patientInfo)
+
+    expect(loadPersistedPatient()).toEqual({ patientId: 123, patientInfo })
+  })
+
+  it('clears the selected patient', () => {
+    const listener = vi.fn()
+    window.addEventListener(PATIENT_CLEARED_EVENT, listener)
+    savePersistedPatient(123, { queueNo: 123 })
+
+    clearPersistedPatient()
+
+    expect(localStorage.getItem('selectedPatient')).toBeNull()
+    expect(loadPersistedPatient()).toEqual({ patientId: -1, patientInfo: {} })
+    expect(listener).toHaveBeenCalledTimes(1)
+    window.removeEventListener(PATIENT_CLEARED_EVENT, listener)
+  })
+})


### PR DESCRIPTION
1. Registering a new user does not properly save it to localStorage. Refreshing clears the newly registered user, unintended
2. Reference 8ed1768 commit: introduce refresh now saves selectedPatient. However, introduces over-persistence that saves across logouts (and hence different accounts can access the previous selectedPatient).