### PR TITLE
Ophthal referral wording, DSG referral on AMT, editable PHQ9 at Geri Cognitive

### DIFF
--- a/src/forms/GeriCognitiveTabs/GeriAmtForm.jsx
+++ b/src/forms/GeriCognitiveTabs/GeriAmtForm.jsx
@@ -1,7 +1,6 @@
 import { Box, Button, CircularProgress, Paper, Typography, Grid, Divider } from '@mui/material'
 import { FastField, Field, Form, Formik } from 'formik'
 import { useContext, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import dayjs from 'dayjs'
 
 import * as Yup from 'yup'
@@ -28,8 +27,6 @@ import {
 
 const formName = 'geriAmtForm'
 
-const AMT_QUESTION_NAMES = Array.from({ length: 10 }, (_, i) => `geriAmtQ${i + 1}`)
-
 const validationSchema = Yup.object({
   ...Object.fromEntries(
     Array.from({ length: 10 }, (_, i) => [
@@ -40,19 +37,7 @@ const validationSchema = Yup.object({
     ]),
   ),
   geriAmtQ11: Yup.string().oneOf(['Before PSLE', 'After PSLE']).required('Required'),
-  geriAmtQ12: Yup.string()
-    .oneOf(['Yes (Eligible for G-RACE)', 'No (Not eligible for G-RACE)'])
-    .required('Required'),
-  // Only asked when the AMT is failed, so only required then.
-  geriAmtQ13: Yup.string().when(['geriAmtQ11', ...AMT_QUESTION_NAMES], {
-    is: (...answers) => {
-      const educationLevel = answers[0]
-      const score = answers.slice(1).filter((v) => v === 'Yes (Answered correctly)').length
-      return hasFailedAmt(score, educationLevel)
-    },
-    then: (schema) => schema.oneOf(['Yes', 'No']).required('Required'),
-    otherwise: (schema) => schema.notRequired(),
-  }),
+  geriAmtQ12: Yup.string().oneOf(['Yes', 'No']).required('Required'),
 })
 
 const formOptions = {
@@ -64,13 +49,9 @@ const formOptions = {
     { label: 'Before PSLE', value: 'Before PSLE' },
     { label: 'After PSLE', value: 'After PSLE' },
   ],
-  geriAmtQ13: [
+  geriAmtQ12: [
     { label: 'Yes', value: 'Yes' },
     { label: 'No', value: 'No' },
-  ],
-  geriAmtQ12: [
-    { label: 'Yes (Eligible for G-RACE)', value: 'Yes (Eligible for G-RACE)' },
-    { label: 'No (Not eligible for G-RACE)', value: 'No (Not eligible for G-RACE)' },
   ],
 }
 
@@ -97,8 +78,7 @@ const initialValues = {
   geriAmtQ9: '',
   geriAmtQ10: '',
   geriAmtQ11: '',
-  geriAmtQ12: '', // Yes/No field
-  geriAmtQ13: '', // DementiaSG referral; only asked when the AMT is failed
+  geriAmtQ12: '', // DSG referral decision, Yes/No
 }
 
 const GeriAmtForm = ({ changeTab, nextTab }) => {
@@ -107,7 +87,6 @@ const GeriAmtForm = ({ changeTab, nextTab }) => {
   const [regForm, setRegForm] = useState(null)
   const [loading, setLoading] = useState(false)
   const [loadingSidePanel, setLoadingSidePanel] = useState(true)
-  const navigate = useNavigate()
 
   useEffect(() => {
     const fetchData = async () => {
@@ -126,23 +105,16 @@ const GeriAmtForm = ({ changeTab, nextTab }) => {
       initialValues={savedData}
       validationSchema={validationSchema}
       onSubmit={async (values, { setSubmitting }) => {
-        // A DementiaSG referral only stands while the AMT is failed; if the score
-        // or education level later changes to a pass, drop the stale answer.
-        const submittedValues = hasFailedAmt(getScore(values), values.geriAmtQ11)
-          ? values
-          : { ...values, geriAmtQ13: '' }
-
         setLoading(true)
-        const response = await submitForm(submittedValues, patientId, formName)
+        const response = await submitForm(values, patientId, formName)
         setLoading(false)
+        setSubmitting(false)
         if (response.result) {
           await showFormSubmitSuccess()
-          // If patient is eligible for G-RACE, navigate to next tab. If not, navigate to PatientTimeline.
-          if (values.geriAmtQ12 === 'Yes (Eligible for G-RACE)') {
-            changeTab(null, nextTab)
-          } else if (values.geriAmtQ12 === 'No (Not eligible for G-RACE)') {
-            navigate('/app/dashboard')
-          }
+          // geriAmtQ12 now records the DSG referral rather than G-RACE eligibility,
+          // so it no longer decides where to go next. Continue to the G-RACE tab,
+          // which stays reachable for whoever needs it.
+          changeTab(null, nextTab)
         } else {
           showFormSubmitError(`Unsuccessful. ${response.error}`)
         }
@@ -234,19 +206,8 @@ const GeriAmtForm = ({ changeTab, nextTab }) => {
                 src='../../../images/geri-amt/g-race-criteria.png'
                 alt='Eligibility for g-race based on education level'
               />
-              <Typography sx={{ fontWeight: 'bold', mt: 3 }}>
-                {geriAmtFormQuestionText.geriAmtQ12(regForm?.registrationQ4)}
-              </Typography>
-              <Field
-                name='geriAmtQ12'
-                label={geriAmtFormQuestionText.geriAmtQ12}
-                component={CustomRadioGroup}
-                options={formOptions.geriAmtQ12}
-                row
-              />
-
-              {/* DementiaSG referral is only offered when the AMT is failed. The
-                  pass mark depends on schooling: >= 7/10 Before PSLE, >= 9/10 After. */}
+              {/* Pass mark depends on schooling: >= 7/10 Before PSLE, >= 9/10 After.
+                  Shown as guidance for the referral decision below. */}
               {(() => {
                 const score = getScore(formikProps.values)
                 const educationLevel = formikProps.values.geriAmtQ11
@@ -255,33 +216,23 @@ const GeriAmtForm = ({ changeTab, nextTab }) => {
 
                 const failed = hasFailedAmt(score, educationLevel)
                 return (
-                  <>
-                    <Typography sx={{ fontWeight: 'bold', mt: 3, color: failed ? 'red' : 'green' }}>
-                      AMT {failed ? 'FAILED' : 'PASSED'}: scored {score}/10, pass mark is {passMark}
-                      /10 for {educationLevel}.
-                    </Typography>
-                    {failed ? (
-                      <>
-                        <Typography sx={{ fontWeight: 'bold', mt: 2 }}>
-                          {geriAmtFormQuestionText.geriAmtQ13}
-                        </Typography>
-                        <Field
-                          name='geriAmtQ13'
-                          label='geriAmtQ13'
-                          component={CustomRadioGroup}
-                          options={formOptions.geriAmtQ13}
-                          row
-                        />
-                      </>
-                    ) : (
-                      <Typography sx={{ mt: 1 }}>
-                        No DementiaSG referral &mdash; only participants who fail the AMT are
-                        referred.
-                      </Typography>
-                    )}
-                  </>
+                  <Typography sx={{ fontWeight: 'bold', mt: 3, color: failed ? 'red' : 'green' }}>
+                    AMT {failed ? 'FAILED' : 'PASSED'}: scored {score}/10, pass mark is {passMark}/10
+                    for {educationLevel}.
+                  </Typography>
                 )
               })()}
+
+              <Typography sx={{ fontWeight: 'bold', mt: 3 }}>
+                {geriAmtFormQuestionText.geriAmtQ12}
+              </Typography>
+              <Field
+                name='geriAmtQ12'
+                label='geriAmtQ12'
+                component={CustomRadioGroup}
+                options={formOptions.geriAmtQ12}
+                row
+              />
             </div>
 
             <ErrorNotification

--- a/src/forms/GeriCognitiveTabs/GeriPhqForm.jsx
+++ b/src/forms/GeriCognitiveTabs/GeriPhqForm.jsx
@@ -5,6 +5,10 @@ import * as Yup from 'yup'
 import { FormContext } from '../../api/utils.js'
 import { getSavedData } from '../../services/patientData'
 import { submitForm } from '../../api/formHelpers.jsx'
+import {
+  showFormSubmitError,
+  showFormSubmitSuccess,
+} from 'src/components/form-components/FormSubmitStatusHost'
 import '../fieldPadding.css'
 import PopupText from 'src/utils/popupText'
 
@@ -50,9 +54,17 @@ const GetScore = () => {
   )
 }
 
+const pointsMap = {
+  '0 - Not at all': 0,
+  '1 - Several days': 1,
+  '2 - More than half the days': 2,
+  '3 - Nearly everyday': 3,
+}
+
 export default function GeriPhqForm({ changeTab, nextTab }) {
   const { patientId } = useContext(FormContext)
   const [savedData, setSavedData] = useState(null)
+  const [loading, setLoading] = useState(false)
 
   const initialValues = {
     PHQ1: '',
@@ -69,19 +81,16 @@ export default function GeriPhqForm({ changeTab, nextTab }) {
     PHQShortAns11: '',
   }
 
+  // PHQ9 is the only field entered here. Everything else is History Taking data
+  // shown for reference, and PHQ3-PHQ8 are no longer collected at all — requiring
+  // them would make this form permanently unsubmittable.
   const validationSchema = Yup.object({
-    PHQ1: Yup.string().oneOf(dayRange).required('Required'),
-    PHQ2: Yup.string().oneOf(dayRange).required('Required'),
-    PHQ3: Yup.string().oneOf(dayRange).required('Required'),
-    PHQ4: Yup.string().oneOf(dayRange).required('Required'),
-    PHQ5: Yup.string().oneOf(dayRange).required('Required'),
-    PHQ6: Yup.string().oneOf(dayRange).required('Required'),
-    PHQ7: Yup.string().oneOf(dayRange).required('Required'),
-    PHQ8: Yup.string().oneOf(dayRange).required('Required'),
     PHQ9: Yup.string().oneOf(dayRange).required('Required'),
-    PHQExtra9: Yup.string().oneOf(yesNo).optional(),
-    PHQ11: Yup.string().oneOf(yesNo).required('Required'),
-    PHQShortAns11: Yup.string().optional(),
+    PHQExtra9: Yup.string().when('PHQ9', {
+      is: (phq9) => Boolean(phq9) && phq9 !== '0 - Not at all',
+      then: (schema) => schema.oneOf(yesNo).required('Required'),
+      otherwise: (schema) => schema.notRequired(),
+    }),
   })
 
   useEffect(() => {
@@ -103,18 +112,43 @@ export default function GeriPhqForm({ changeTab, nextTab }) {
     return <CircularProgress />
   }
 
+  const handleSubmit = async (values, { setSubmitting }) => {
+    // Only PHQ9 and its follow-up are entered here; the rest is reference data
+    // from History Taking and must not be written back.
+    const submittedValues = {
+      PHQ9: values.PHQ9,
+      PHQExtra9: values.PHQ9 === '0 - Not at all' ? '' : values.PHQExtra9,
+      // Keep the running PHQ total in step with the answer just recorded.
+      PHQ10:
+        (pointsMap[values.PHQ1] || 0) +
+        (pointsMap[values.PHQ2] || 0) +
+        (pointsMap[values.PHQ9] || 0),
+    }
+
+    setLoading(true)
+    const response = await submitForm(submittedValues, patientId, formName)
+    setLoading(false)
+    setSubmitting(false)
+    if (response.result) {
+      await showFormSubmitSuccess()
+      if (changeTab) changeTab(null, nextTab)
+    } else {
+      showFormSubmitError(`Unsuccessful. ${response.error}`)
+    }
+  }
+
   return (
     <Paper elevation={2}>
       <Formik
         initialValues={savedData}
         validationSchema={validationSchema}
         enableReinitialize
-        onSubmit={() => {}}
+        onSubmit={handleSubmit}
       >
-        {(handleSubmit, errors, submitCount) => (
+        {({ isSubmitting, errors, submitCount }) => (
           <Form className='fieldPadding'>
             <Typography variant='h6' color='error' fontWeight='bold'>
-              **This form is duplicate of the HX PHQ form (read-only)**
+              **PHQ1-PHQ8 are from History Taking. Please complete PHQ9 below.**
             </Typography>
             <Typography variant='subtitle1' fontWeight='bold'>
               Over the last 2 weeks, how often have you been bothered by any of the following
@@ -127,47 +161,55 @@ export default function GeriPhqForm({ changeTab, nextTab }) {
               </Typography>
             )}
 
+            {/* PHQ1-PHQ8 are recorded at History Taking and shown here for reference only. */}
             <DisabledWrapper>
-              {['PHQ1', 'PHQ2', 'PHQ3', 'PHQ4', 'PHQ5', 'PHQ6', 'PHQ7', 'PHQ8', 'PHQ9'].map(
-                (name, i) => (
-                  <FastField
-                    key={name}
-                    name={name}
-                    label={`${i + 1}. ${geriPhqFormQuestionText[name]}`}
-                    component={CustomRadioGroup}
-                    options={dayRange.map((val) => ({ label: val, value: val }))}
-                    row
-                  />
-                ),
-              )}
-
-              <br />
-
-              <PopupText
-                qnNo='PHQ9'
-                triggerValue={[
-                  '1 - Several days',
-                  '2 - More than half the days',
-                  '3 - Nearly everyday',
-                ]}
-              >
+              {['PHQ1', 'PHQ2', 'PHQ3', 'PHQ4', 'PHQ5', 'PHQ6', 'PHQ7', 'PHQ8'].map((name, i) => (
                 <FastField
-                  name='PHQExtra9'
-                  label={geriPhqFormQuestionText.PHQExtra9}
+                  key={name}
+                  name={name}
+                  label={`${i + 1}. ${geriPhqFormQuestionText[name]}`}
                   component={CustomRadioGroup}
-                  options={yesNo.map((v) => ({ label: v, value: v }))}
+                  options={dayRange.map((val) => ({ label: val, value: val }))}
                   row
                 />
-              </PopupText>
-              <PopupText qnNo='PHQExtra9' triggerValue='Yes'>
-                <Typography variant='subtitle1' sx={{ color: 'red' }}>
-                  <b>
-                    *Patient requires urgent attention, please escalate to supervisor of the station
-                    to bring to Doctor&apos;s station*
-                  </b>
-                </Typography>
-              </PopupText>
+              ))}
+            </DisabledWrapper>
 
+            {/* PHQ9 is entered at this station. */}
+            <Typography variant='subtitle1' fontWeight='bold' sx={{ mt: 2 }}>
+              Please complete the following:
+            </Typography>
+            <FastField
+              name='PHQ9'
+              label={`9. ${geriPhqFormQuestionText.PHQ9}`}
+              component={CustomRadioGroup}
+              options={dayRange.map((val) => ({ label: val, value: val }))}
+              row
+            />
+
+            {/* Follow-up to PHQ9, so it is entered here too. */}
+            <PopupText
+              qnNo='PHQ9'
+              triggerValue={['1 - Several days', '2 - More than half the days', '3 - Nearly everyday']}
+            >
+              <FastField
+                name='PHQExtra9'
+                label={geriPhqFormQuestionText.PHQExtra9}
+                component={CustomRadioGroup}
+                options={yesNo.map((v) => ({ label: v, value: v }))}
+                row
+              />
+            </PopupText>
+            <PopupText qnNo='PHQExtra9' triggerValue='Yes'>
+              <Typography variant='subtitle1' sx={{ color: 'red' }}>
+                <b>
+                  *Patient requires urgent attention, please escalate to supervisor of the station to
+                  bring to Doctor&apos;s station*
+                </b>
+              </Typography>
+            </PopupText>
+
+            <DisabledWrapper>
               <Typography variant='subtitle1' fontWeight='bold'>
                 Score:
               </Typography>
@@ -190,10 +232,21 @@ export default function GeriPhqForm({ changeTab, nextTab }) {
               />
               <ErrorMessage name='PHQShortAns11' component='div' style={{ color: 'red' }} />
 
-              <Typography variant='body2' color='text.secondary'>
-                This form is read-only. Please edit the HX PHQ form instead.
-              </Typography>
             </DisabledWrapper>
+
+            <Typography variant='body2' color='text.secondary' sx={{ mt: 2 }}>
+              Greyed-out answers were recorded at History Taking and cannot be edited here.
+            </Typography>
+
+            <div style={{ marginTop: 16, display: 'flex', justifyContent: 'center' }}>
+              {loading || isSubmitting ? (
+                <CircularProgress />
+              ) : (
+                <Button type='submit' variant='contained' color='primary'>
+                  Submit
+                </Button>
+              )}
+            </div>
           </Form>
         )}
       </Formik>

--- a/src/forms/questions/GeriAmtFormQuestions.js
+++ b/src/forms/questions/GeriAmtFormQuestions.js
@@ -10,9 +10,8 @@ export const geriAmtFormQuestionText = {
   geriAmtQ9: 'Count backwards from 20 to 1. 请您从二十开始，倒数到一。',
   geriAmtQ10: 'Recall memory phase 请您把刚才我要您记住的地址重复一遍。',
   geriAmtQ11: '11) What is your highest education level attained?',
-  geriAmtQ12: (age) =>
-    `Follow the criteria shown in the image above. 12) Based on the patient's age (${age}), education level and AMT score, is the patient eligible for G-RACE for MMSE?`,
-  geriAmtQ13: '13) Refer to DementiaSG?',
+  geriAmtQ12:
+    "12) Based on the patient's years of education and AMT score, do you need to refer to DSG?",
 }
 
 // AMT pass mark depends on schooling: >= 7/10 for Before PSLE (under 6 years of

--- a/src/forms/questions/OphthalFormQuestions.jsx
+++ b/src/forms/questions/OphthalFormQuestions.jsx
@@ -14,7 +14,7 @@ export const ophthalFormQuestionText = {
   OphthalQ11: (
     <>
       Please <u>refer to Doctor&apos;s Consult</u> if pinhole visual acuity is{' '}
-      <u>worse than 6/12</u>
+      <u>worse than 6/12</u> and <u>does not correct with pinhole</u>
     </>
   ),
   OphthalQ12: '1. Does the participant wish to apply for the Senior Mobility Fund?',

--- a/test/unit/GeriPhqForm.test.jsx
+++ b/test/unit/GeriPhqForm.test.jsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormContext } from '../../src/api/utils'
+import GeriPhqForm from '../../src/forms/GeriCognitiveTabs/GeriPhqForm'
+import { getSavedData } from '../../src/services/patientData'
+import { submitForm } from '../../src/api/formHelpers.jsx'
+
+vi.mock('../../src/api/formHelpers.jsx', () => ({ submitForm: vi.fn() }))
+vi.mock('src/components/form-components/FormSubmitStatusHost', () => ({
+  showFormSubmitError: vi.fn(),
+  showFormSubmitSuccess: vi.fn(),
+}))
+vi.mock('../../src/services/patientData', () => ({ getSavedData: vi.fn() }))
+
+const NONE = '0 - Not at all'
+const SEVERAL = '1 - Several days'
+const HALF = '2 - More than half the days'
+
+const renderForm = () =>
+  render(
+    <FormContext.Provider value={{ patientId: 7 }}>
+      <GeriPhqForm changeTab={vi.fn()} nextTab={1} />
+    </FormContext.Provider>,
+  )
+
+describe('Geri Cognitive PHQ form', () => {
+  beforeEach(() => {
+    submitForm.mockResolvedValue({ result: true })
+    getSavedData.mockResolvedValue({ PHQ1: HALF, PHQ2: SEVERAL })
+  })
+
+  it('renders PHQ9 as an editable question with a Submit button', async () => {
+    renderForm()
+
+    expect(await screen.findByText(/Thoughts that you would be better off dead/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument()
+  })
+
+  it('lets PHQ9 be selected and saves only PHQ9, its follow-up and the score', async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    await screen.findByText(/Thoughts that you would be better off dead/)
+
+    // PHQ9 = "Not at all" -> no follow-up required, submit succeeds.
+    const noneRadios = await screen.findAllByRole('radio', { name: NONE })
+    await user.click(noneRadios[noneRadios.length - 1])
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+    expect(submitForm).toHaveBeenCalledTimes(1)
+    const [payload, , formName] = submitForm.mock.calls[0]
+    expect(formName).toBe('geriPhqForm')
+    expect(Object.keys(payload).sort()).toEqual(['PHQ10', 'PHQ9', 'PHQExtra9'])
+    expect(payload.PHQ9).toBe(NONE)
+    expect(payload.PHQExtra9).toBe('')
+    // PHQ1 (2) + PHQ2 (1) + PHQ9 (0)
+    expect(payload.PHQ10).toBe(3)
+  })
+
+  it('does not write History Taking answers back to the database', async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    await screen.findByText(/Thoughts that you would be better off dead/)
+    const noneRadios = await screen.findAllByRole('radio', { name: NONE })
+    await user.click(noneRadios[noneRadios.length - 1])
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+    const [payload] = submitForm.mock.calls[0]
+    for (const field of ['PHQ1', 'PHQ2', 'PHQ3', 'PHQ8', 'PHQ11', 'PHQShortAns11']) {
+      expect(payload).not.toHaveProperty(field)
+    }
+  })
+
+  it('reveals the follow-up when PHQ9 is not "Not at all"', async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    await screen.findByText(/Thoughts that you would be better off dead/)
+    expect(screen.queryByText(/Do you want to take your life now/)).toBeNull()
+
+    const severalRadios = await screen.findAllByRole('radio', { name: SEVERAL })
+    await user.click(severalRadios[severalRadios.length - 1])
+
+    expect(await screen.findByText(/Do you want to take your life now/)).toBeInTheDocument()
+  })
+})

--- a/test/unit/PhqNineRepro.test.jsx
+++ b/test/unit/PhqNineRepro.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormContext } from '../../src/api/utils'
+import HxPhqForm from '../../src/forms/HistoryTakingTabs/HxPhqForm'
+import { getSavedData } from '../../src/services/patientData'
+import { submitForm } from '../../src/api/formHelpers.jsx'
+
+vi.mock('../../src/api/formHelpers.jsx', () => ({ submitForm: vi.fn() }))
+vi.mock('src/components/form-components/FormSubmitStatusHost', () => ({
+  showFormSubmitError: vi.fn(),
+  showFormSubmitSuccess: vi.fn(),
+}))
+vi.mock('../../src/services/patientData', () => ({ getSavedData: vi.fn() }))
+
+const SEVERAL = '1 - Several days'
+const HALF = '2 - More than half the days'
+const PHQ9_TEXT = /PHQ9\. Thoughts that you would be better off dead/
+
+const renderForm = () =>
+  render(<FormContext.Provider value={{ patientId: 7 }}>
+    <HxPhqForm changeTab={vi.fn()} nextTab={1} />
+  </FormContext.Provider>)
+
+// CustomRadioGroup renders one radio per option per question, in DOM order.
+// index 0-3 = PHQ1, 4-7 = PHQ2.
+const pick = async (user, questionIndex, optionLabel) => {
+  const radios = await screen.findAllByRole('radio', { name: optionLabel })
+  await user.click(radios[questionIndex])
+}
+
+describe('PHQ9 reveal at the cutoff', () => {
+  beforeEach(() => {
+    submitForm.mockResolvedValue({ result: true })
+    getSavedData.mockResolvedValue({})
+  })
+
+  it('reveals PHQ9 when PHQ1 is set first, then PHQ2 (real volunteer order)', async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    await pick(user, 0, HALF) // PHQ1 = 2
+    expect(screen.queryByText(PHQ9_TEXT)).toBeNull()
+
+    await pick(user, 1, SEVERAL) // PHQ2 = 1  -> total 3
+    expect(await screen.findByText(PHQ9_TEXT)).toBeInTheDocument()
+  })
+
+  it('reveals PHQ9 when both are set to "Several days" then one raised', async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    await pick(user, 0, SEVERAL) // PHQ1 = 1
+    await pick(user, 1, SEVERAL) // PHQ2 = 1 -> total 2
+    expect(screen.queryByText(PHQ9_TEXT)).toBeNull()
+
+    await pick(user, 0, HALF) // PHQ1 = 2 -> total 3
+    expect(await screen.findByText(PHQ9_TEXT)).toBeInTheDocument()
+  })
+
+  it('reveals PHQ9 when the form loads with saved answers already at the cutoff', async () => {
+    getSavedData.mockResolvedValue({ PHQ1: HALF, PHQ2: SEVERAL })
+    renderForm()
+
+    expect(await screen.findByText(PHQ9_TEXT)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Three station form changes.

**Ophthalmology — `OphthalQ11`**
Guidance now reads: refer to Doctor's Consult if pinhole visual acuity is worse than 6/12 *and does not correct with pinhole*. The checkbox and its Doctor's Station referral wiring were already in place; only the wording changed.

**Geri Cognitive / AMT — `geriAmtQ12`**
Repurposed from G-RACE eligibility to the DSG referral: *"Based on the patient's years of education and AMT score, do you need to refer to DSG?"* (Yes/No, required). The AMT pass mark is shown above it as guidance — >= 7/10 for Before PSLE, >= 9/10 for After PSLE — and only once education level is answered, so an unanswered level is never treated as a failure.

⚠️ `isEligibleForGrace` in the backend (`forms.service.js`) compares `geriAmtQ12 === "Yes (Eligible for G-RACE)"`, a value this form no longer produces, so that flag will now always be false. Left unchanged deliberately — needs a decision on whether G-RACE is still running this year.

**Geri Cognitive / PHQ — `PHQ9`**
The tab was entirely read-only with a no-op submit. PHQ9 and its follow-up are now editable and submittable; PHQ1–PHQ8 stay locked as History Taking reference. Validation previously required PHQ1–PHQ8, which History Taking no longer collects, so the form could never have been submitted. Submit writes only `PHQ9`, `PHQExtra9` and `PHQ10`.

Also fixes a Formik render-prop destructuring bug (`(handleSubmit, errors, submitCount)` treated one object as three arguments) and a "Functions are not valid as a React child" warning from passing a function as a `label`.

275 tests pass (2 new files), lint clean, production build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)