### PR TITLE
Form A: add Geriatrics assessment and consult tick boxes

### DIFF
--- a/src/reports/formAPdf.js
+++ b/src/reports/formAPdf.js
@@ -141,7 +141,31 @@ function eligibilitySection(stations, pmhx = {}) {
     gericog: {
       number: '12',
       label: 'Geriatric Screening',
-      details: { text: '>= 60 years old', fontSize: 9 },
+      details: {
+        stack: [
+          { text: '>= 60 years old', fontSize: 9 },
+          ...[
+            'OT Questionnaire (HOMEFAST)',
+            'PT Questionnaire (PAL Qx)',
+            'Physical Tests (SPPB)',
+          ].map((label) => ({
+            columns: [
+              { image: uncheckedBox, width: 10, margin: [-2, 0, 5, 0] },
+              { text: label, fontSize: 9 },
+            ],
+          })),
+          { text: 'Recommendation:', fontSize: 9, bold: true, margin: [0, 2, 0, 0] },
+          {
+            columns: [
+              { image: uncheckedBox, width: 10, margin: [-2, 0, 5, 0] },
+              { text: 'PT consult', fontSize: 9, width: 'auto', margin: [0, 0, 12, 0] },
+              { image: uncheckedBox, width: 10, margin: [-2, 0, 5, 0] },
+              { text: 'OT consult', fontSize: 9, width: 'auto' },
+              { text: '' },
+            ],
+          },
+        ],
+      },
     },
     ophthal: { number: '12b', label: 'Visual Acuity' },
     hpv: { number: '13', label: 'HPV On-Site Testing' },

--- a/test/unit/PhqSubmitGate.test.jsx
+++ b/test/unit/PhqSubmitGate.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormContext } from '../../src/api/utils'
+import HxPhqForm from '../../src/forms/HistoryTakingTabs/HxPhqForm'
+import { getSavedData } from '../../src/services/patientData'
+import { submitForm } from '../../src/api/formHelpers.jsx'
+
+vi.mock('../../src/api/formHelpers.jsx', () => ({ submitForm: vi.fn() }))
+vi.mock('src/components/form-components/FormSubmitStatusHost', () => ({
+  showFormSubmitError: vi.fn(),
+  showFormSubmitSuccess: vi.fn(),
+}))
+vi.mock('../../src/services/patientData', () => ({ getSavedData: vi.fn() }))
+
+const NONE = '0 - Not at all'
+const SEVERAL = '1 - Several days'
+const HALF = '2 - More than half the days'
+
+const renderForm = () =>
+  render(
+    <FormContext.Provider value={{ patientId: 7 }}>
+      <HxPhqForm changeTab={vi.fn()} nextTab={1} />
+    </FormContext.Provider>,
+  )
+
+// Fill everything the form always requires, except PHQ9.
+const fillRequiredExceptPhq9 = async (user, { phq1, phq2 }) => {
+  const pick = async (name, value) => {
+    const el = document.querySelector(`input[name="${name}"][value="${value}"]`)
+    await user.click(el)
+  }
+  await pick('PHQ1', phq1)
+  await pick('PHQ2', phq2)
+  await pick('GAD1', NONE)
+  await pick('GAD2', NONE)
+  await pick('PHQ11', 'No')
+}
+
+describe('History Taking PHQ: can you submit without PHQ9?', () => {
+  beforeEach(() => {
+    submitForm.mockResolvedValue({ result: true })
+    getSavedData.mockResolvedValue({})
+  })
+
+  it('BELOW the cutoff (PHQ-2 = 2): submits fine, PHQ9 never asked', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await screen.findAllByRole('radio', { name: NONE })
+
+    await fillRequiredExceptPhq9(user, { phq1: SEVERAL, phq2: SEVERAL })
+    expect(screen.queryByText(/PHQ9\. Thoughts/)).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+    expect(submitForm).toHaveBeenCalledTimes(1)
+  })
+
+  it('AT the cutoff (PHQ-2 = 3): submission is BLOCKED until PHQ9 is answered', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await screen.findAllByRole('radio', { name: NONE })
+
+    await fillRequiredExceptPhq9(user, { phq1: HALF, phq2: SEVERAL })
+    expect(await screen.findByText(/PHQ9\. Thoughts/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+    expect(submitForm).not.toHaveBeenCalled()
+
+    // Answering PHQ9 unblocks it.
+    await user.click(document.querySelector(`input[name="PHQ9"][value="${NONE}"]`))
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+    expect(submitForm).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/unit/formAPdf.test.js
+++ b/test/unit/formAPdf.test.js
@@ -134,8 +134,24 @@ describe('generateFormAPdf', () => {
       'Long Term Follow Up',
     ])
     expect(stationRows.every(([, modality]) => modality.fontSize === 10)).toBe(true)
-    expect(JSON.stringify(eligibilityTable)).not.toMatch(/Cognitive|Mobility|PT Consult|OT Consult/)
+    // Geriatrics is a single "Geriatric Screening" row — the Cognitive/Mobility
+    // split is not surfaced on Form A.
+    expect(JSON.stringify(eligibilityTable)).not.toMatch(/Cognitive|Mobility/)
     expect(stationRows[0][4].text).toBe('Mammobus is located at the Community Centre (CC) carpark.')
+
+    // Geriatric Screening lists the three mobility assessments, then a
+    // Recommendation line with PT/OT consult tick boxes. All boxes print unticked.
+    const geriDetails = stationRows.find(([, modality]) => modality.text === 'Geriatric Screening')[4]
+    expect(geriDetails.stack[0].text).toBe('>= 60 years old')
+    expect(geriDetails.stack.slice(1, 4).map((row) => row.columns[1].text)).toEqual([
+      'OT Questionnaire (HOMEFAST)',
+      'PT Questionnaire (PAL Qx)',
+      'Physical Tests (SPPB)',
+    ])
+    expect(geriDetails.stack[4].text).toBe('Recommendation:')
+    const recommendation = geriDetails.stack[5].columns
+    expect(recommendation.map((c) => c.text).filter(Boolean)).toEqual(['PT consult', 'OT consult'])
+    expect(JSON.stringify(geriDetails).match(/unchecked-box/g)).toHaveLength(5)
 
     const publicAssistance = docDefinition.content.find(
       (section) => section.columns?.[0]?.text === 'Public Assistance Card:',


### PR DESCRIPTION
Adds tick boxes to the **Geriatric Screening** row (12) on Form A.

```
│ 12 │ Geriatric Screening │ YES │ YES / NO │ >= 60 years old               │
│    │                     │     │          │ ☐ OT Questionnaire (HOMEFAST) │
│    │                     │     │          │ ☐ PT Questionnaire (PAL Qx)   │
│    │                     │     │          │ ☐ Physical Tests (SPPB)       │
│    │                     │     │          │ Recommendation:               │
│    │                     │     │          │ ☐ PT consult  ☐ OT consult    │
```

All five boxes print **unticked** and are entirely static — nothing is read from the patient record. Uses the same `uncheckedBox` asset as the Healthier SG row so they match the rest of the form.

The `ELIGIBLE?` column is unchanged and still fills from the eligibility rules.

### Note on an existing assertion

`formAPdf.test.js` asserted Form A must not mention PT/OT Consult:

```js
expect(...).not.toMatch(/Cognitive|Mobility|PT Consult|OT Consult/)
```

Narrowed to `/Cognitive|Mobility/` — the Cognitive/Mobility station split still shouldn't surface on Form A, but PT/OT consult now does by design. Worth confirming with whoever added that exclusion.

Added coverage asserting all five labels and five unticked boxes.

### Also included

`test/unit/PhqSubmitGate.test.jsx` — covers the History Taking PHQ submit gate, which nothing previously tested: PHQ9 is not required below the PHQ-2 cutoff of 3, and blocks submission at or above it.

283 tests pass, lint clean, production build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)