### PR TITLE
HCSR Review: add Maybe(Refer to M4/M5) option and reword hxHcsrQ7

### DIFF
--- a/src/forms/HistoryTakingTabs/HxHcsrReviewForm.jsx
+++ b/src/forms/HistoryTakingTabs/HxHcsrReviewForm.jsx
@@ -23,14 +23,21 @@ const initialValues = {
   hxHcsrShortAnsQ7: '',
 }
 
+const MAYBE_M4M5 = 'Maybe(Refer to M4/M5)'
+
+// "Yes" refers to the Doctor's Station via the backend eligibility rule; "Maybe"
+// defers that decision to the M4/M5 Review tab instead. Both ask for a reason.
+const REASON_REQUIRED_ANSWERS = ['Yes', MAYBE_M4M5]
+
 const validationSchema = Yup.object({
-  hxHcsrQ7: Yup.string().oneOf(['Yes', 'No']).required('Required'),
+  hxHcsrQ7: Yup.string().oneOf(['Yes', 'No', MAYBE_M4M5]).required('Required'),
 })
 
 const formOptions = {
   hxHcsrQ7: [
     { label: 'Yes', value: 'Yes' },
     { label: 'No', value: 'No' },
+    { label: MAYBE_M4M5, value: MAYBE_M4M5 },
   ],
 }
 
@@ -60,7 +67,9 @@ export default function HxHcsrReviewForm({ changeTab, nextTab }) {
   const handleSubmit = async (values, { setSubmitting }) => {
     const submittedValues = {
       ...values,
-      hxHcsrShortAnsQ7: values.hxHcsrQ7 === 'Yes' ? values.hxHcsrShortAnsQ7 : '',
+      hxHcsrShortAnsQ7: REASON_REQUIRED_ANSWERS.includes(values.hxHcsrQ7)
+        ? values.hxHcsrShortAnsQ7
+        : '',
     }
     setLoading(true)
     const response = await submitForm(submittedValues, patientId, formName)
@@ -98,7 +107,7 @@ export default function HxHcsrReviewForm({ changeTab, nextTab }) {
               row
             />
 
-            <PopupText qnNo='hxHcsrQ7' triggerValue='Yes'>
+            <PopupText qnNo='hxHcsrQ7' triggerValue={REASON_REQUIRED_ANSWERS}>
               <Typography variant='subtitle1' fontWeight='bold'>
                 {hxHcsrFormQuestionText.hxHcsrShortAnsQ7}
               </Typography>

--- a/src/forms/questions/HxHcsrFormQuestions.jsx
+++ b/src/forms/questions/HxHcsrFormQuestions.jsx
@@ -15,7 +15,7 @@ export const hxHcsrFormQuestionText = {
   hxHcsrQ5:
     'If you are 60 and above, do you currently use hearing aids/have been detected to require hearing aids?',
   hxHcsrQ7:
-    'Please indicate if you feel that HEALTH CONCERNS require closer scrutiny by doctors later or if participant strongly insists.',
+    'From the history taken, do you feel that HEALTH CONCERNS require closer scrutiny by doctors later or if participant strongly insists.',
   hxHcsrShortAnsQ7: 'Please specify:',
   hxhcsrQ8: (
     <>

--- a/test/unit/HxHcsrReviewMaybe.test.jsx
+++ b/test/unit/HxHcsrReviewMaybe.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormContext } from '../../src/api/utils'
+import HxHcsrReviewForm from '../../src/forms/HistoryTakingTabs/HxHcsrReviewForm'
+import { getSavedData } from '../../src/services/patientData'
+import { submitForm } from '../../src/api/formHelpers.jsx'
+
+vi.mock('../../src/api/formHelpers.jsx', () => ({ submitForm: vi.fn() }))
+vi.mock('src/components/form-components/FormSubmitStatusHost', () => ({
+  showFormSubmitError: vi.fn(),
+  showFormSubmitSuccess: vi.fn(),
+}))
+vi.mock('../../src/services/patientData', () => ({ getSavedData: vi.fn() }))
+
+const MAYBE = 'Maybe(Refer to M4/M5)'
+const REASON = /Please specify/i
+
+const renderForm = () =>
+  render(
+    <FormContext.Provider value={{ patientId: 7 }}>
+      <HxHcsrReviewForm changeTab={vi.fn()} nextTab={1} />
+    </FormContext.Provider>,
+  )
+
+const pick = async (user, value) => {
+  const el = document.querySelector(`input[name="hxHcsrQ7"][value="${value}"]`)
+  await user.click(el)
+}
+
+describe('HCSR Review — Maybe(Refer to M4/M5) option', () => {
+  beforeEach(() => {
+    submitForm.mockResolvedValue({ result: true })
+    getSavedData.mockResolvedValue({})
+  })
+
+  it('offers Yes, No and Maybe', async () => {
+    renderForm()
+    await screen.findByRole('radio', { name: 'Yes' })
+
+    expect(screen.getByRole('radio', { name: 'Yes' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'No' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: MAYBE })).toBeInTheDocument()
+  })
+
+  it('submits successfully when Maybe is selected', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await screen.findByRole('radio', { name: MAYBE })
+
+    await pick(user, MAYBE)
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    expect(submitForm).toHaveBeenCalledTimes(1)
+    expect(submitForm.mock.calls[0][0].hxHcsrQ7).toBe(MAYBE)
+  })
+
+  it('shows the reason box for both Yes and Maybe, but not No', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await screen.findByRole('radio', { name: 'Yes' })
+
+    expect(screen.queryByText(REASON)).toBeNull()
+
+    await pick(user, 'Yes')
+    expect(await screen.findByText(REASON)).toBeInTheDocument()
+
+    await pick(user, MAYBE)
+    expect(await screen.findByText(REASON)).toBeInTheDocument()
+
+    await pick(user, 'No')
+    expect(screen.queryByText(REASON)).toBeNull()
+  })
+
+  it('keeps the reason on Maybe and clears it on No', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await screen.findByRole('radio', { name: MAYBE })
+
+    await pick(user, MAYBE)
+    await user.type(
+      document.querySelector('textarea[name="hxHcsrShortAnsQ7"]'),
+      'Unclear, defer to M4/M5',
+    )
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    expect(submitForm.mock.calls[0][0].hxHcsrShortAnsQ7).toBe('Unclear, defer to M4/M5')
+
+    submitForm.mockClear()
+    await pick(user, 'No')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    expect(submitForm.mock.calls[0][0].hxHcsrShortAnsQ7).toBe('')
+  })
+
+  it('leaves the Yes flow unchanged', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await screen.findByRole('radio', { name: 'Yes' })
+
+    await pick(user, 'Yes')
+    await user.type(document.querySelector('textarea[name="hxHcsrShortAnsQ7"]'), 'Chest pain')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    const [payload] = submitForm.mock.calls[0]
+    expect(payload.hxHcsrQ7).toBe('Yes')
+    expect(payload.hxHcsrShortAnsQ7).toBe('Chest pain')
+  })
+})


### PR DESCRIPTION
### The question

> From the history taken, do you feel that HEALTH CONCERNS require closer scrutiny by doctors later or if participant strongly insists.

(reworded from *"Please indicate if you feel that..."*)

### The option

`hxHcsrQ7` now offers **Yes / No / Maybe(Refer to M4/M5)**.

The "Please specify" box appears for **Yes and Maybe**, and the reason is kept on submit for both — so a Maybe reaches M4/M5 with the history taker's reasoning attached rather than a bare "unsure".

### Yes is unchanged

Same reason box, same Doctor's Station referral, same display in the Doctor's Consult side panel (which already prints the answer *and* the reason beneath it).

### No backend change needed

The Doctor's Station rule tests `hcsrreview?.hxHcsrQ7 === "Yes"`. `"Maybe(Refer to M4/M5)"` isn't `"Yes"`, so it doesn't refer directly — it defers to the M4/M5 Review tab, which is the next tab and already gates that whole branch via `hxM4M5Q1 === "Yes"`. So: no rule change, no `stationProjection` change, **no `ELIGIBILITY_RULES_VERSION` bump, and no manual backend deploy.** This is live as soon as the frontend merges.

### Implementation note

The answer strings are pulled into `MAYBE_M4M5` / `REASON_REQUIRED_ANSWERS` constants. The option list, the `oneOf` validation, the popup trigger and the submit handler all reference the same values — that four-way duplication is exactly how a widened option list ends up rejected by a stale `oneOf`.

### Tests

Five new cases: all three options render; Maybe submits successfully; the reason box shows for Yes and Maybe but not No; the reason survives Maybe and is cleared on No; and the Yes flow is unchanged.

303 tests pass, lint clean, production build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)